### PR TITLE
fix: minor technical mistake on page 68 - expectedVisits instead of visits

### DIFF
--- a/listings/05-07.cs
+++ b/listings/05-07.cs
@@ -6,6 +6,6 @@ public class LogVisit
     {
         _db.Execute(@“UPDATE Users SET visits=visits+1
                       WHERE user_id=@p1 and visits = @p2”,
-                      userId, visits);
+                      userId, expectedVisits);
     }
 }


### PR DESCRIPTION
On page 68, 2nd code sample, the 3rd parameter in `_db.Execute()` should be `expectedVisits` instead of `visits`.